### PR TITLE
#100 Maj des pastilles dans la tabbar lorsqu'il y a du nouveau conten…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { SplashScreen } from '@awesome-cordova-plugins/splash-screen/ngx';
 import { StatusBar } from '@awesome-cordova-plugins/status-bar/ngx';
 import { FpmaApiService } from './services/fpma-api.service';
 import { ContentUpdateService } from './services/content-update.service';
-import type { LastVisitTimestamps, LastVisitUpdates } from './models/lastVisitTimestamps.interface';
+import type { LastVisitTimestamps } from './models/lastVisitTimestamps.interface';
 import { StorageService } from './utils/storage.service';
 import { FirebaseAnalytics } from '@awesome-cordova-plugins/firebase-analytics/ngx';
 import OneSignal from 'onesignal-cordova-plugin';
@@ -169,14 +169,14 @@ export class AppComponent {
     });
   }
 
-  private checkNbUpdatedContent(): Observable<LastVisitUpdates> {
+  private checkNbUpdatedContent(): Observable<LastVisitTimestamps> {
     return from(this.storage.get<LastVisitTimestamps>('lastVisitTimestamp')).pipe(
       switchMap((val: LastVisitTimestamps) => {
         if (val) {
-          return this.fpmaService.getContentUpdated(val).pipe(
-            filter((timestamps): timestamps is LastVisitUpdates => !!timestamps),
+          return this.fpmaService.getContentUpdated().pipe(
+            filter((timestamps): timestamps is LastVisitTimestamps => !!timestamps),
             tap(contentUpdated =>
-              this.contentUpdateService.initNbUpdated(contentUpdated)
+              this.contentUpdateService.initUpdatedStatus(val, contentUpdated)
             )
           );
         } else {

--- a/src/app/models/lastVisitTimestamps.interface.ts
+++ b/src/app/models/lastVisitTimestamps.interface.ts
@@ -4,10 +4,3 @@ export interface LastVisitTimestamps {
   partages: number;
   events: number;
 }
-
-export interface LastVisitUpdates {
-  broadcasts: number;
-  news: number;
-  partages: number;
-  events: number;
-}

--- a/src/app/services/content-update.service.ts
+++ b/src/app/services/content-update.service.ts
@@ -1,51 +1,51 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
-import { LastVisitTimestamps, LastVisitUpdates } from '../models/lastVisitTimestamps.interface';
+import { LastVisitTimestamps } from '../models/lastVisitTimestamps.interface';
 import { StorageService } from '../utils/storage.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ContentUpdateService {
-  private eventUpdateObservable = new Subject<number>();
-  private broadcastUpdateObservable = new Subject<number>();
-  private newsUpdateObservable = new Subject<number>();
-  private partageUpdateObservable = new Subject<number>();
+  private eventUpdateObservable = new Subject<boolean>();
+  private broadcastUpdateObservable = new Subject<boolean>();
+  private newsUpdateObservable = new Subject<boolean>();
+  private partageUpdateObservable = new Subject<boolean>();
 
 
   constructor(private storage: StorageService) {}
 
-  public initNbUpdated(lastVisitUpdated: LastVisitUpdates) {
-    this.updateBroadcastsNb(lastVisitUpdated.broadcasts);
-    this.updateEventsNb(lastVisitUpdated.events);
-    this.updateNewsNb(lastVisitUpdated.news);
-    this.updatePartagesNb(lastVisitUpdated.partages);
+  public initUpdatedStatus(storedVisitTimestamp: LastVisitTimestamps, lastVisitTimestamp: LastVisitTimestamps) {
+    this.updateBroadcastsStatus(storedVisitTimestamp.broadcasts < lastVisitTimestamp.broadcasts);
+    this.updateEventsStatus(storedVisitTimestamp.events < lastVisitTimestamp.events);
+    this.updateNewsStatus(storedVisitTimestamp.news < lastVisitTimestamp.news);
+    this.updatePartagesStatus(storedVisitTimestamp.partages < lastVisitTimestamp.partages);
   }
 
-  public getEventUpdateObservable(): Observable<number> {
+  public getEventUpdateObservable(): Observable<boolean> {
     return this.eventUpdateObservable.asObservable();
   }
-  public getBroadcastUpdateObservable(): Observable<number> {
+  public getBroadcastUpdateObservable(): Observable<boolean> {
     return this.broadcastUpdateObservable.asObservable();
   }
-  public getNewsUpdateObservable(): Observable<number> {
+  public getNewsUpdateObservable(): Observable<boolean> {
     return this.newsUpdateObservable.asObservable();
   }
-  public getPartageUpdateObservable(): Observable<number> {
+  public getPartageUpdateObservable(): Observable<boolean> {
     return this.partageUpdateObservable.asObservable();
   }
 
-  public updateBroadcastsNb(nbBroadcastssUpdated: number): void {
+  public updateBroadcastsStatus(nbBroadcastssUpdated: boolean): void {
     this.broadcastUpdateObservable.next(nbBroadcastssUpdated);
   }
 
-  public updateEventsNb(nbEventsUpdated: number): void {
+  public updateEventsStatus(nbEventsUpdated: boolean): void {
     this.eventUpdateObservable.next(nbEventsUpdated);
   }
-  public updateNewsNb(nbNewsUpdated: number): void {
+  public updateNewsStatus(nbNewsUpdated: boolean): void {
     this.newsUpdateObservable.next(nbNewsUpdated);
   }
-  public updatePartagesNb(nbPartagesUpdated: number): void {
+  public updatePartagesStatus(nbPartagesUpdated: boolean): void {
     this.partageUpdateObservable.next(nbPartagesUpdated);
   }
 
@@ -61,22 +61,22 @@ export class ContentUpdateService {
   public resetNbUpdated(content: keyof LastVisitTimestamps) {
     switch (content) {
       case 'broadcasts' : {
-        this.updateBroadcastsNb(0);
+        this.updateBroadcastsStatus(false);
         void this.updateEpochTimeStored('broadcasts');
         break;
       }
       case 'events' : {
-        this.updateEventsNb(0);
+        this.updateEventsStatus(false);
         void this.updateEpochTimeStored('events');
         break;
       }
       case 'partages' : {
-        this.updatePartagesNb(0);
+        this.updatePartagesStatus(false);
         void this.updateEpochTimeStored('partages');
         break;
       }
       case 'news' : {
-        this.updateNewsNb(0);
+        this.updateNewsStatus(false);
         void this.updateEpochTimeStored('news');
         break;
       }

--- a/src/app/services/fpma-api.service.ts
+++ b/src/app/services/fpma-api.service.ts
@@ -6,7 +6,7 @@ import type { Actualities } from '../models/actuality.interface';
 import type { AgendaEvent } from '../models/agenda-event.interface';
 import type { ArticleSpi } from '../models/article-spi.interface';
 import type { GenericPost } from '../models/generic-post.interface';
-import type { LastVisitTimestamps, LastVisitUpdates } from '../models/lastVisitTimestamps.interface';
+import type { LastVisitTimestamps } from '../models/lastVisitTimestamps.interface';
 import type { LiveSection } from '../models/live-section.interface';
 import type { Presentation } from '../models/presentation.interface';
 import type { StkNews } from '../models/stk-news.interface';
@@ -385,26 +385,20 @@ export class FpmaApiService {
     }
   }
 
-  public getContentUpdated(lastVisitTimestamps: LastVisitTimestamps): Observable<LastVisitUpdates | null> {
-    const params = new HttpParams()
-                      .set('broadcasts', lastVisitTimestamps.broadcasts.toString())
-                      .set('events', lastVisitTimestamps.events.toString())
-                      .set('news', lastVisitTimestamps.news.toString())
-                      .set('partages', lastVisitTimestamps.partages.toString());
-    return this.http.get<APIResponse<'content-updates', RawContentUpdate>>(`${this.FPMA_DOMAIN}api/content-updates`, { params })
+  public getContentUpdated(): Observable<LastVisitTimestamps | null> {
+    return this.http.get<RawContentUpdate>(`${this.FPMA_DOMAIN}api/content-updates`)
       .pipe(
         map(res => this.parseContentUpdates(res)),
         );
   }
 
-  private parseContentUpdates(data: APIResponse<'content-updates', RawContentUpdate>): LastVisitUpdates | null {
-    const contentUpdated = data?.['content-updates'] ?? null;
-    if ( contentUpdated && contentUpdated.data) {
+  private parseContentUpdates(data: RawContentUpdate): LastVisitTimestamps | null {
+    if (data) {
       return {
-        broadcasts: contentUpdated.data.broadcasts,
-        events: contentUpdated.data.events,
-        news: contentUpdated.data.news,
-        partages: contentUpdated.data.partages
+        broadcasts: data.broadcastsLatestTs,
+        events: data.eventsLatestTs,
+        news: data.stkNewsLatestTs,
+        partages: data.partagesLatestTs
       };
     } else {
       return null;
@@ -466,5 +460,5 @@ interface RawNews extends RawPartage {
   files: string[];
 }
 
-export type RawContentUpdate = Record<'broadcasts' | 'events' | 'news' | 'partages', number>;
+export type RawContentUpdate = Record<'broadcastsLatestTs' | 'eventsLatestTs' | 'stkNewsLatestTs' | 'partagesLatestTs', number>;
 

--- a/src/app/tabs/tabs.page.scss
+++ b/src/app/tabs/tabs.page.scss
@@ -19,3 +19,21 @@ ion-tab-bar {
     }
   }
 }
+
+.tab-layout-icon-top.new {
+  position: relative;
+}
+
+.tab-layout-icon-top.new:before {
+  content: '';
+  display: block;
+  position: absolute;
+  text-align: right;
+  width: 0.3em;
+  height: 0.3em;
+  top: 10%;
+  right: calc(25% - 0.3em);
+  border-radius: 50%;
+  border: 0.3em solid red;
+  background: red;
+}

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { ContentUpdateService } from '../services/content-update.service';
 
 @Component({
@@ -8,58 +8,52 @@ import { ContentUpdateService } from '../services/content-update.service';
 })
 export class TabsPage {
 
-  constructor(private contentUpdateService: ContentUpdateService) {
-    this.contentUpdateService.getBroadcastUpdateObservable().subscribe( (nbBroadcasts) => {
-      this.updateNotificationIcon('broadcastNotification', nbBroadcasts);
+  constructor(private eltRef: ElementRef<HTMLElement>, private contentUpdateService: ContentUpdateService) {
+    this.contentUpdateService.getBroadcastUpdateObservable().subscribe( (isNew) => {
+      this.updateNotificationIcon('broadcastNotification', isNew);
     });
-    this.contentUpdateService.getEventUpdateObservable().subscribe( (nbEvents) => {
-      this.updateNotificationIcon('eventNotification', nbEvents);
+    this.contentUpdateService.getEventUpdateObservable().subscribe( (isNew) => {
+      this.updateNotificationIcon('eventNotification', isNew);
     });
-    this.contentUpdateService.getNewsUpdateObservable().subscribe( (nbNews) => {
-      this.updateNotificationIcon('newsNotification', nbNews);
+    this.contentUpdateService.getNewsUpdateObservable().subscribe( (isNew) => {
+      this.updateNotificationIcon('newsNotification', isNew);
     });
-    this.contentUpdateService.getPartageUpdateObservable().subscribe( (nbPartages) => {
-      this.updateNotificationIcon('partageNotification', nbPartages);
+    this.contentUpdateService.getPartageUpdateObservable().subscribe( (isNew) => {
+      this.updateNotificationIcon('partageNotification', isNew);
     });
   }
 
-  private updateNotificationIcon(id: string, nb: number) {
+  private updateNotificationIcon(id: string, isNew: boolean) {
     setTimeout(() => {
-      const existingElmt = document.getElementById(id);
-      if (existingElmt) {
-        if (nb) {
-          existingElmt.innerHTML = nb.toString();
-        } else {
-          existingElmt.remove();
-        }
+      let tabId: number = -1;
+      switch (id) {
+        case 'broadcastNotification':
+          tabId = 1
+          break;
+        case 'eventNotification':
+          tabId = 5
+          break;
+        case 'newsNotification':
+          tabId = 4
+          break;
+        case 'partageNotification':
+          tabId = 3
+          break;
+      }
+
+      const el: Element | undefined = this.eltRef.nativeElement.getElementsByClassName('tab-layout-icon-top')[tabId];
+      if (!el) {
+        return;
+      }
+
+      // Si la rubrique contient du nouveau contenu
+      // on rajoute la class CSS "new"
+      if (isNew) {
+        el.classList.add('new');
       } else {
-        if (nb) {
-          const spanNb = document.createElement('SPAN');
-          spanNb.id = id;
-          spanNb.innerHTML = nb.toString();
-          this.createElementNotification(spanNb, id);
-        }
+        el.classList.remove('new');
       }
     }, 1000);
-}
-
-private createElementNotification(element: HTMLSpanElement, id: string) {
-  switch (id) {
-    case 'broadcastNotification':
-      document.getElementsByClassName('tab-layout-icon-top')[1].appendChild(element);
-      break;
-    case 'eventNotification':
-      document.getElementsByClassName('tab-layout-icon-top')[5].appendChild(element);
-      break;
-    case 'newsNotification':
-      document.getElementsByClassName('tab-layout-icon-top')[4].appendChild(element);
-      break;
-    case 'partageNotification':
-      document.getElementsByClassName('tab-layout-icon-top')[3].appendChild(element);
-      break;
-    default:
-      console.log(`no notification`);
   }
-}
 
 }


### PR DESCRIPTION
Hello @hearoy 

côté API, nous n'envoyons plus le nb d'articles mis à jour par catégorie, mais juste le timestamp du dernier article pour chaque catégorie. 
J'ai donc mis à jour les pastilles dans la tabbar. Aujourd'hui, pour afficher les "badges" avec le nb d'articles nouveaux, on manipule directement le DOM pour rajouter une span.
Pour faire simple (et surtout parce que j'ai pas les compétences en Angular), j'ai gardé le même principe mais je rajoute une class CSS au lieu d'un span.

Je serai honoré si tu pouvais faire la code review 👍 

PS : la branche est tirée de la `feature/105-upgrade-to-angular-14`

Merci !