### PR TITLE
#144 Fix refresh token

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,7 +11,7 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { IonicStorageModule } from '@ionic/storage-angular';
 import { FirebaseAnalytics } from '@awesome-cordova-plugins/firebase-analytics/ngx';
 import { OneSignal } from '@awesome-cordova-plugins/onesignal/ngx';
-import { JwtModule, JWT_OPTIONS } from '@auth0/angular-jwt';
+import { JwtModule, JWT_OPTIONS, JwtInterceptor, JwtHelperService } from '@auth0/angular-jwt';
 import { initializeTokensFromStorage, jwtOptionsFactory } from './profile/auth.service';
 import { AuthExpirationInterceptor } from './profile/auth/auth-expiration.interceptor';
 
@@ -24,12 +24,6 @@ import { AuthExpirationInterceptor } from './profile/auth/auth-expiration.interc
       }),
       AppRoutingModule,
       HttpClientModule,
-      JwtModule.forRoot({
-          jwtOptionsProvider: {
-              provide: JWT_OPTIONS,
-              useFactory: jwtOptionsFactory,
-          }
-      }),
       IonicStorageModule.forRoot(),
     ],
     providers: [
@@ -39,6 +33,19 @@ import { AuthExpirationInterceptor } from './profile/auth/auth-expiration.interc
         OneSignal,
         { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
         { provide: HTTP_INTERCEPTORS, multi: true, useClass: AuthExpirationInterceptor },
+        /* copied from `JwtModule.forRoot` to set the JWT interceptor after AuthExpirationInterceptor
+         https://github.com/auth0/angular2-jwt/blob/main/projects/angular-jwt/src/lib/angular-jwt.module.ts */
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: JwtInterceptor,
+          multi: true,
+        },
+        {
+          provide: JWT_OPTIONS,
+          useFactory: jwtOptionsFactory,
+        },
+        JwtHelperService,
+
         { provide: APP_INITIALIZER, multi: true, useFactory: initializeTokensFromStorage }
     ],
     bootstrap: [AppComponent]

--- a/src/app/profile/auth.service.ts
+++ b/src/app/profile/auth.service.ts
@@ -1,11 +1,13 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { JwtConfig, JwtHelperService } from '@auth0/angular-jwt';
-import { StorageService } from '../utils/storage.service';
 import { differenceInMinutes } from 'date-fns/esm';
-import { BehaviorSubject, combineLatest, EMPTY, firstValueFrom, forkJoin, Observable, of } from 'rxjs';
-import { map, shareReplay, switchMap, take, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, EMPTY, firstValueFrom, forkJoin, Observable, of, timer } from 'rxjs';
+import { distinctUntilChanged, filter, map, retry, shareReplay, switchMap, take, tap } from 'rxjs/operators';
+import { StorageService } from '../utils/storage.service';
+import { FpmaApiService } from './../services/fpma-api.service';
 
 const AUTH_STORAGE_KEY = 'auth_token';
 const REFRESH_STORAGE_KEY = 'refresh_token';
@@ -22,138 +24,103 @@ export interface MyStkJwtPayload {
 }
 // standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
 export interface JwtPayload {
-  iss?: string | undefined;
-  sub?: string | undefined;
   aud?: string | string[] | undefined;
   exp?: number | undefined;
-  nbf?: number | undefined;
   iat?: number | undefined;
+  iss?: string | undefined;
   jti?: string | undefined;
+  nbf?: number | undefined;
+  sub?: string | undefined;
 }
 
 export function initializeTokensFromStorage() {
   const storage = inject(StorageService);
-  return () => Promise.all([
-    storage.get<string>(REFRESH_STORAGE_KEY).then(refreshToken => refreshToken && refreshToken$.next(refreshToken)),
-    storage.get<string>(AUTH_STORAGE_KEY).then(jwtString => jwtString && accessToken$.next(jwtString)),
-  ]);
+  return () =>
+    Promise.all([
+      storage.get<string>(REFRESH_STORAGE_KEY).then((refreshToken) => refreshToken && refreshToken$.next(refreshToken)),
+      storage.get<string>(AUTH_STORAGE_KEY).then((jwtString) => jwtString && accessToken$.next(jwtString)),
+    ]);
 }
 
 export function jwtOptionsFactory(): JwtConfig {
   return {
     allowedDomains: ['stk.fpma.church'],
-    disallowedRoutes: [
-      new RegExp(String.raw`/api/mystk/auth/.*`),
-    ],
+    disallowedRoutes: [new RegExp(String.raw`/api/mystk/auth/.*`)],
     tokenGetter: () => firstValueFrom(accessToken$.pipe(take(1))),
   };
 }
 
-const accessToken$ = new BehaviorSubject<string|null>(null);
-const refreshToken$ = new BehaviorSubject<string|null>(null);
+const accessToken$ = new BehaviorSubject<string | null>(null);
+const refreshToken$ = new BehaviorSubject<string | null>(null);
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthService {
-
+  private readonly accessTokenPayload$: Observable<(JwtPayload & MyStkJwtPayload) | null> =
+    this.getAccessTokenPayload();
   private readonly baseAPI = 'https://stk.fpma.church/api/mystk';
-  private readonly accessTokenPayload$: Observable<JwtPayload & MyStkJwtPayload | null>  = this.getAccessTokenPayload();
-  private readonly userId$ = this.accessTokenPayload$.pipe(
-    map(jwt => jwt?.sub),
-  );
   private isRefreshing$ = new BehaviorSubject(false);
-
+  private readonly userId$ = this.accessTokenPayload$.pipe(map((jwt) => jwt?.sub));
+  private fpmaService = inject(FpmaApiService);
   constructor(
     private storage: StorageService,
     private http: HttpClient,
     private jwtHelper: JwtHelperService,
-    private router: Router,
-  ) {
-  }
-
+    private router: Router
+  ) {}
 
   getMyId() {
-    return this.userId$.pipe(
-      take(1),
+    return this.userId$.pipe(take(1));
+  }
+
+  isAccesTokenExpired$() {
+    return accessToken$.pipe(map((token) => (token ? this.jwtHelper.isTokenExpired(token) : true)));
+  }
+
+  isLoggedIn$() {
+    return combineLatest([this.userId$, this.isAccesTokenExpired$()]).pipe(
+      map(([userId, expired]) => !!userId && !expired)
     );
   }
 
+  isPasswordTemporary$() {
+    return this.accessTokenPayload$.pipe(map((payload) => payload?.recoveryPasswordExpiration));
+  }
+
   logIn(login: string, password: string) {
-    return this.http.post<AuthPairResponse>(`${this.baseAPI}/auth`, { login, password }).pipe(
-      switchMap(({ accessToken, refreshToken }) => forkJoin([
-        this.setAccesToken(accessToken),
-        this.setRefreshToken(refreshToken)
-      ])),
-    )
+    return this.http
+      .post<AuthPairResponse>(`${this.baseAPI}/auth`, { login, password })
+      .pipe(
+        switchMap(({ accessToken, refreshToken }) =>
+          forkJoin([this.setAccesToken(accessToken), this.setRefreshToken(refreshToken)])
+        )
+      );
   }
 
   async logOut(redirect = true) {
     await this.setAccesToken(null);
     await this.setRefreshToken(null);
-    this.isPasswordTemporary$().pipe(
-      switchMap(isTemporary => isTemporary
-        ? this.invalidateRefreshToken()
-        : of(true),
-      )
-    )
+    this.isPasswordTemporary$()
+      .pipe(switchMap((isTemporary) => (isTemporary ? this.invalidateRefreshToken() : of(true))))
       .subscribe();
     return redirect ? this.router.navigateByUrl('/') : Promise.resolve(false);
   }
 
-  private invalidateRefreshToken() {
-    const refreshToken = refreshToken$.value;
-    return refreshToken
-      ? this.http.post(`${this.baseAPI}/auth/token/invalidate`, { refreshToken })
-      : of();
-  }
-
-  isLoggedIn$() {
-    return combineLatest([
-      this.userId$,
-      this.isAccesTokenExpired$(),
-    ]).pipe(
-      map(([userId, expired]) => !!userId && !expired),
-    );
-  }
-
-  isPasswordTemporary$() {
-    return this.accessTokenPayload$.pipe(
-      map(payload => payload?.recoveryPasswordExpiration),
-    )
-  }
-
-  shouldRefresh$() {
-    return accessToken$.pipe(
-      map(token => token
-          ? differenceInMinutes(this.jwtHelper.getTokenExpirationDate(token) ?? new Date(), new Date()) < 5
-          : true
-        ),
-    )
-  }
-  isAccesTokenExpired$() {
-    return accessToken$.pipe(
-      map(token => token
-          ? this.jwtHelper.isTokenExpired(token)
-          : true,
-        ),
-    )
-  }
-
   /**
    * Uses the refresh token to refresh the access token. If no refresh token is available, complete immediately.
+   * Completes without emitting any value to signify it couldn't refresh (AuthExpirationInterceptor relies on that behaviour)
    */
   refresh() {
     return combineLatest([refreshToken$, this.userId$]).pipe(
       take(1),
       switchMap(([refreshToken, userId]) => {
         if (this.isRefreshing$.value) {
-          return of(false);
-          // return this.isRefreshing$.pipe(
-          //   distinctUntilChanged(),
-          //   filter(isRefreshing => !isRefreshing),
-          //   take(1),
-          // );
+          return this.isRefreshing$.pipe(
+            distinctUntilChanged(),
+            filter((isRefreshing) => !isRefreshing),
+            take(1)
+          );
         }
         if (!!refreshToken && userId) {
           this.isRefreshing$.next(true);
@@ -162,24 +129,56 @@ export class AuthService {
           return EMPTY;
         }
       }),
-      switchMap((tokensOrRefresh) => typeof tokensOrRefresh === 'boolean'
-        ? of(null)
-        : forkJoin([
-          this.setAccesToken(tokensOrRefresh.accessToken),
-          this.setRefreshToken(tokensOrRefresh.refreshToken)
-        ])),
+      switchMap((tokensOrRefresh) =>
+        typeof tokensOrRefresh === 'boolean'
+          ? of(null)
+          : forkJoin([
+              this.setAccesToken(tokensOrRefresh.accessToken),
+              this.setRefreshToken(tokensOrRefresh.refreshToken),
+            ]).pipe(tap(() => this.isRefreshing$.next(false)))
+      ),
       tap({
-        next: () => this.isRefreshing$.next(false),
-        error: () => {
-          this.isRefreshing$.next(false);
-          this.setRefreshToken(null);
+        // eslint-disable-next-line rxjs/no-implicit-any-catch
+        error: (e: HttpErrorResponse) => {
+          console.error(e);
         },
       }),
-    )
+      retry({
+        count: 3,
+        resetOnSuccess: true,
+        delay: (error: HttpErrorResponse, retryCount) => {
+          if (error.status === 0) {
+            return timer((1000 * 2) ^ retryCount).pipe(take(1));
+          } else {
+            this.isRefreshing$.next(false);
+            return of(1);
+          }
+        },
+      }),
+      tap({
+        next: (r) => {
+          if (typeof ngDevMode !== 'undefined' && !!ngDevMode || this.fpmaService.isDevMode) {
+            console.log('refreshed %o', r);
+          }
+        },
+        error: () => {
+          this.isRefreshing$.next(false);
+          void this.setRefreshToken(null);
+        },
+      })
+    );
   }
 
-  resetPassword(body: { email: string; }) {
+  resetPassword(body: { email: string }) {
     return this.http.post(`${this.baseAPI}/resetpassword`, body);
+  }
+
+  shouldRefresh$() {
+    return accessToken$.pipe(
+      map((token) =>
+        token ? differenceInMinutes(this.jwtHelper.getTokenExpirationDate(token) ?? new Date(), new Date()) < 5 : true
+      )
+    );
   }
 
   private getAccessTokenPayload() {
@@ -187,22 +186,24 @@ export class AuthService {
       return this.accessTokenPayload$;
     } else {
       return accessToken$.pipe(
-        map(jwtString => jwtString
-          ? this.jwtHelper.decodeToken<JwtPayload & MyStkJwtPayload>(jwtString)
-          : null,
-        ),
-        shareReplay({ refCount: false, bufferSize: 1 }),
+        map((jwtString) => (jwtString ? this.jwtHelper.decodeToken<JwtPayload & MyStkJwtPayload>(jwtString) : null)),
+        shareReplay({ refCount: false, bufferSize: 1 })
       );
     }
   }
 
-  private setRefreshToken(refreshToken: string | null): Promise<unknown> {
-    refreshToken$.next(refreshToken);
-    return this.storage.set(REFRESH_STORAGE_KEY, refreshToken);
+  private invalidateRefreshToken() {
+    const refreshToken = refreshToken$.value;
+    return refreshToken ? this.http.post(`${this.baseAPI}/auth/token/invalidate`, { refreshToken }) : of();
   }
 
   private setAccesToken(accessToken: string | null): Promise<unknown> {
     accessToken$.next(accessToken);
     return this.storage.set(AUTH_STORAGE_KEY, accessToken);
+  }
+
+  private setRefreshToken(refreshToken: string | null): Promise<unknown> {
+    refreshToken$.next(refreshToken);
+    return this.storage.set(REFRESH_STORAGE_KEY, refreshToken);
   }
 }

--- a/src/app/profile/auth/auth-expiration.interceptor.ts
+++ b/src/app/profile/auth/auth-expiration.interceptor.ts
@@ -36,11 +36,11 @@ export class AuthExpirationInterceptor implements HttpInterceptor {
               isEmpty(),
               catchError((error: HttpErrorResponse) => {
                 if (error.status === 401) {
-                  return throwError(this.router.navigateByUrl('/login')).pipe(
+                  return throwError(() => this.router.navigateByUrl('/login')).pipe(
                     switchMap(() => EMPTY)
                   );
                 } else {
-                  return throwError(error);
+                  return throwError(() => error);
                 }
               }),
               switchMap((wontRefresh) => {


### PR DESCRIPTION
- réordonnancement des interceptors pour que le refresh se fasse avant l'ajout du auth bearer 
  - évite d'utiliser un ancien auth token 
  - bloque les requêtes s'il faut rafraîchir le token
- correction de la queue d'attente des requêtes si un refresh est en cours

fixes #144